### PR TITLE
Actually install Jekyll 3.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ yum install -y ruby ruby-devel nginx && \
 yum clean all -y
 
 # Install Jekyll and Bundler with RubyGems
-RUN gem install jekyll bundler
+RUN gem install jekyll -v 3.2.1
+RUN gem install bundler
 
 # Copy the S2I scripts to /usr/libexec/s2i, since openshift/base-centos7
 # image sets io.openshift.s2i.scripts-url label that way


### PR DESCRIPTION
Previously the Dockerfile would retrieve the default version of Jekyll
when installing the gem. This caused issues because the default Ruby
version on RHEL7 is < 2.1, and the package public_suffix requires a Ruby
version >=2.1