### PR TITLE
Fix Jekyll bundle support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Steven Mirabito <smirabito@csh.rit.edu>
 # Inform about software versions being used inside the builder
 ENV JEKYLL_VERSION=3.2.1
 ENV BUNDLE_PATH=/opt/app-root/bundle
+ENV LC_ALL=en_US.UTF-8
 
 # Labels used in OpenShift to describe the builder image
 LABEL io.k8s.description="Platform for building Jekyll-based static sites" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Steven Mirabito <smirabito@csh.rit.edu>
 
 # Inform about software versions being used inside the builder
 ENV JEKYLL_VERSION=3.2.1
+ENV BUNDLE_PATH=/opt/app-root/bundle
 
 # Labels used in OpenShift to describe the builder image
 LABEL io.k8s.description="Platform for building Jekyll-based static sites" \


### PR DESCRIPTION
Before:
```
---> Building site with Jekyll...
Configuration file: /tmp/src/_config.yml
Source: /tmp/src
Destination: /opt/app-root/src
Incremental build: disabled. Enable with --incremental
Generating...
bundler: failed to load command: jekyll (/opt/app-root/src/bin/jekyll)
LoadError: cannot load such file -- jekyll/errors
```

After:
```
---> Building site with Jekyll...
Configuration file: /tmp/src/_config.yml
Source: /tmp/src
Destination: /opt/app-root/src
Incremental build: disabled. Enable with --incremental
Generating...
done in 1.355 seconds.
Auto-regeneration: disabled. Use --watch to enable.
Build completed successfully
```